### PR TITLE
Added locked cursor position while dragging

### DIFF
--- a/FreeserfNet/GameView.cs
+++ b/FreeserfNet/GameView.cs
@@ -542,7 +542,9 @@ namespace Freeserf
 
         bool RunHandler(EventHandler handler, EventArgs args)
         {
-            handler?.Invoke(this, args);
+            bool? h = handler?.Invoke(this, args);
+            if (h.HasValue)
+                args.Done = h.Value;
 
             return args.Done;
         }

--- a/Silk.NET.Window/Window.cs
+++ b/Silk.NET.Window/Window.cs
@@ -29,7 +29,7 @@ namespace Silk.NET.Window
         );
 
         readonly IWindow window = null;
-        IMouse mouse = null;
+        public IMouse mouse = null;
         bool cursorVisible = true;
 
         private static WindowOptions CreateOptions(string title, Point position, Size size)


### PR DESCRIPTION
Hello,

This PR demonstrates a working way to lock the cursor when dragging is activated (mentioned here https://github.com/Pyrdacor/freeserf.net/issues/101). This is the way the dragging works in the original DOS version of Settlers. It is also more usable, because if the cursor moves while being dragged, the cursor might reach the edge of the window and interrupt the dragging.

The implementation is a bit hacky. Implementing the locking requires the use of `mouse.Cursor.CursorMode = CursorMode.Raw;` which is a private attribute inside `Silk.NET.Window/Window.cs`. As it is, the locking logic resides now in `MainWindow.cs`, which is not ideal I suppose. It might be better suited in `FreeserfNet/GameView.cs -> NotifyDrag()`. However, this would mean that there would have be a way to control the `CursorMode` from there, but I will leave the architectural decisions to you.

I also edited the `RunHandler` to poll information whether dragging was successfully allowed. Not really sure if it was meant to be used this way originally.

Tested in Linux x64 build only.