### PR TITLE
Use a more appropriate log directory on Linux

### DIFF
--- a/FreeserfNet/MainWindow.cs
+++ b/FreeserfNet/MainWindow.cs
@@ -75,10 +75,12 @@ namespace Freeserf
             if (mainWindow != null)
                 throw new ExceptionFreeserf(ErrorSystemType.Application, "A main window can not be created twice.");
 
+            string logDirectory = string.Empty;
+
             try
             {
 #if !DEBUG
-                string logDirectory = FileSystem.Paths.IsWindows() ? Program.ExecutablePath : "/var/log/freeserf.net";
+                logDirectory = FileSystem.Paths.IsWindows() ? Program.ExecutablePath : Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "/freeserf";
                 string logPath = Path.Combine(logDirectory, UserConfig.DefaultLogFile);
                 Directory.CreateDirectory(logDirectory);
                 Log.SetStream(new LogFileStream(logPath));
@@ -114,7 +116,7 @@ namespace Freeserf
                     string logFile = string.IsNullOrWhiteSpace(UserConfig.Logging.LogFileName) ? UserConfig.DefaultLogFile : UserConfig.Logging.LogFileName;
 
                     if (!Path.IsPathRooted(logFile))
-                        logFile = Path.Combine(Program.ExecutablePath, logFile);
+                        logFile = Path.Combine(logDirectory, logFile);
 
                     Log.SetStream(new LogFileStream(logFile));
                     Log.MaxSize = UserConfig.Logging.MaxLogSize;


### PR DESCRIPTION
I have managed to get this to run beautifully on ArchLinux, but I had to make a few changes to the code. One of the problems were the default Linux log directory. 

This PR changes the default log directory on Linux to `$HOME/.local/share/freeserf` because standard users usually do not have any write permissions to the `/var/log/freeserf.net` directory. Furthermore the log directory cannot be `Program.ExecutablePath` either, also because the user does not have write permissions to that folder.